### PR TITLE
Migrate data pipelines to Iceberg table format with merge strategy

### DIFF
--- a/opentofu/modules/data_explorer/src/duckdb_init.sql
+++ b/opentofu/modules/data_explorer/src/duckdb_init.sql
@@ -1,24 +1,25 @@
--- DuckDB Initialization Script
--- This script sets up GCS access and creates views for parquet files
--- Variables will be substituted by envsubst or Python string formatting
+-- DuckDB Initialization Script for Iceberg Tables
+-- This script sets up GCS access and creates views for Iceberg tables
 
--- Install and load httpfs extension
+-- Install required extensions
 INSTALL httpfs;
+INSTALL iceberg;
 LOAD httpfs;
+LOAD iceberg;
 
 -- Create GCS secret using environment variable placeholders
--- $SECRET_TYPE will be substituted with either "SECRET" or "PERSISTENT SECRET"
 CREATE $SECRET_TYPE (TYPE GCS, KEY_ID '$HMAC_ACCESS_ID', SECRET '$HMAC_SECRET');
 
 -- Create raw schema
 CREATE SCHEMA IF NOT EXISTS raw;
 
--- Create views using bucket name placeholder
+-- Create views for Iceberg tables
+-- Note: Iceberg tables store metadata files that DuckDB can read directly
 CREATE OR REPLACE VIEW raw.expenses AS
-SELECT * FROM read_parquet('gcs://$GCS_BUCKET_NAME/raw/expenses/data.parquet');
+SELECT * FROM iceberg_scan('gcs://$GCS_BUCKET_NAME/raw/expenses');
 
 CREATE OR REPLACE VIEW raw.monthly_category_amounts AS
-SELECT * FROM read_parquet('gcs://$GCS_BUCKET_NAME/raw/monthly_category_amounts/data.parquet');
+SELECT * FROM iceberg_scan('gcs://$GCS_BUCKET_NAME/raw/monthly_category_amounts');
 
 CREATE OR REPLACE VIEW raw.rate AS
-SELECT * FROM read_parquet('gcs://$GCS_BUCKET_NAME/raw/rate/data.parquet');
+SELECT * FROM iceberg_scan('gcs://$GCS_BUCKET_NAME/raw/rate');

--- a/opentofu/modules/gsheets_pipeline/src/main.py
+++ b/opentofu/modules/gsheets_pipeline/src/main.py
@@ -5,21 +5,31 @@ from google_sheets import google_spreadsheet
 
 @functions_framework.http
 def gsheets_pipeline(request):
-    """
-    Will load all the sheets in the spreadsheet, but it will not load any of the named ranges in the spreadsheet.
-    """
+    """Loads Google Sheets data using Iceberg format."""
+    
     pipeline = dlt.pipeline(
         pipeline_name="gsheets_pipeline",
         destination="filesystem",
         dataset_name="raw",
     )
-    monthly_category_amounts = google_spreadsheet(range_names=["Data", "Rate"])
-    monthly_category_amounts.resources["Data"].apply_hints(
-        table_name="monthly_category_amounts"
+    
+    source = google_spreadsheet(range_names=["Data", "Rate"])
+    
+    # Configure monthly_category_amounts with Iceberg
+    source.resources["Data"].apply_hints(
+        table_name="monthly_category_amounts",
+        table_format="iceberg",  # Enable Iceberg format
+        write_disposition="replace",  # Budget data typically replaces entirely
     )
-    monthly_category_amounts.resources["Rate"].apply_hints(table_name="rate")
+    
+    # Configure rate data with Iceberg  
+    source.resources["Rate"].apply_hints(
+        table_name="rate",
+        table_format="iceberg",  # Enable Iceberg format
+        write_disposition="replace",  # Rate data typically replaces entirely
+    )
 
-    monthly_category_amounts_info = pipeline.run(monthly_category_amounts)
-    print(monthly_category_amounts_info)
+    load_info = pipeline.run(source)
+    print(load_info)
 
     return "Pipeline run successfully!"

--- a/opentofu/modules/gsheets_pipeline/src/pyproject.toml
+++ b/opentofu/modules/gsheets_pipeline/src/pyproject.toml
@@ -5,9 +5,9 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.8"
 dependencies = [
-    "dlt[parquet]>=1.5.0",
-    "dlt[gs]>=1.5.0",
-    "dlt[filesystem]>=0.3.5",
+    "dlt[filesystem,gcs,pyiceberg]>=1.5.0",
+    "sqlalchemy>=2.0.18",
+    "functions-framework",
     "google-api-python-client>=2.166.0",
 ]
 

--- a/opentofu/modules/notion_pipeline/src/main.py
+++ b/opentofu/modules/notion_pipeline/src/main.py
@@ -7,9 +7,7 @@ from notion import notion_databases
 
 @functions_framework.http
 def notion_pipeline(request):
-    """Loads all databases from a Notion workspace which have been shared with
-    an integration.
-    """
+    """Loads expenses from Notion database using Iceberg format with merge strategy."""
     database_id = os.environ.get("SOURCES__NOTION__DATABASE_ID")
 
     pipeline = dlt.pipeline(
@@ -17,18 +15,33 @@ def notion_pipeline(request):
         destination="filesystem",
         dataset_name="raw",
     )
+    
+    # Configure expenses resource with Iceberg and merge strategy
     expenses = notion_databases(database_ids=[{"id": database_id}])
-
-    expenses_info = pipeline.run(
-        expenses,
+    
+    # Apply Iceberg configuration with merge strategy
+    expenses.resources[database_id].apply_hints(
         table_name="expenses",
+        table_format="iceberg",  # Enable Iceberg format
+        primary_key="id",  # Required for merge operations
+        write_disposition={
+            "disposition": "merge", 
+            "strategy": "upsert"  # Use upsert for insert/update operations
+        },
+        # Add incremental loading with cursor
+        incremental=dlt.sources.incremental(
+            "last_edited_time",  # Notion's last modified field
+            initial_value="1970-01-01T00:00:00.000Z"
+        ),
         columns={
             "properties__amount__number": {"data_type": "double"},
             "properties__amount_brl__number": {"data_type": "double"},
             "properties__date__date__start": {"data_type": "date"},
             "properties__debit_credit__formula__number": {"data_type": "double"},
-        },
+        }
     )
+
+    expenses_info = pipeline.run(expenses)
     print(expenses_info)
 
     return "Pipeline run successfully!"

--- a/opentofu/modules/notion_pipeline/src/pyproject.toml
+++ b/opentofu/modules/notion_pipeline/src/pyproject.toml
@@ -5,9 +5,9 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.8"
 dependencies = [
-    "dlt[parquet]>=1.5.0",
-    "dlt[gs]>=1.5.0",
-    "dlt[filesystem]>=0.3.5",
+    "dlt[filesystem,gcs,pyiceberg]>=1.5.0",
+    "sqlalchemy>=2.0.18",
+    "functions-framework",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Migrates both Notion and Google Sheets pipelines from standard Parquet files to Apache Iceberg table format with merge strategy to improve data ingestion performance and enable advanced data lake capabilities.

## Changes
- Updated pyproject.toml files to include pyiceberg extra and SQLAlchemy dependency
- Modified Notion pipeline to use Iceberg format with merge/upsert strategy and incremental loading
- Updated Google Sheets pipeline to use Iceberg format with replace strategy
- Updated DuckDB initialization to use iceberg_scan() instead of read_parquet()
- Added iceberg extension installation in DuckDB init script

Closes #2

Generated with [Claude Code](https://claude.ai/code)